### PR TITLE
fix(storage): Stabilize localStorage and refactor hooks

### DIFF
--- a/src/hooks/useWorkouts.js
+++ b/src/hooks/useWorkouts.js
@@ -1,33 +1,16 @@
-import { useState, useEffect } from 'react';
+import useLocalStorage from './useLocalStorage';
 
-/**
- * Custom hook for managing state that persists to localStorage
- * @param {string} key - The localStorage key
- * @param {any} initialValue - Default value if key doesn't exist
- * @returns {[any, function]} - [storedValue, setValue]
- */
-const useLocalStorage = (key, initialValue) => {
-  // Get initial value from localStorage or use provided initialValue
-  const [storedValue, setStoredValue] = useState(() => {
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      console.error(`Error loading ${key} from localStorage:`, error);
-      return initialValue;
-    }
-  });
+const useWorkouts = () => {
+  const [workouts, setWorkouts] = useLocalStorage('workouts', []);
 
-  // Update localStorage whenever storedValue changes
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(key, JSON.stringify(storedValue));
-    } catch (error) {
-      console.error(`Error saving ${key} to localStorage:`, error);
-    }
-  }, [key, storedValue]);
+  const addWorkout = (workout) => {
+    setWorkouts((prevWorkouts) => [
+      ...prevWorkouts,
+      { ...workout, id: Date.now().toString(), date: new Date().toISOString() },
+    ]);
+  };
 
-  return [storedValue, setStoredValue];
+  return { workouts, addWorkout };
 };
 
-export default useLocalStorage;
+export default useWorkouts;


### PR DESCRIPTION
- Robust `useLocalStorage` Hook:
  - The `useLocalStorage` hook now safely checks for `null` or the string `"undefined"` before calling `JSON.parse()`, preventing crashes on initial load or with invalid data.
  - When a value is set to `undefined`, the corresponding key is now correctly removed from localStorage instead of storing the string `"undefined"`.

- Code Refactoring:
  - Eliminated code duplication by removing the local `useLocalStorage` implementation within `useWorkouts.js`.
  - `useWorkouts.js` now imports and utilizes the centralized and more robust `useLocalStorage` hook, improving maintainability and consistency.
